### PR TITLE
Export firebase admin as default

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -27,3 +27,4 @@ if (!admin.apps.length) {
 
 export const db = admin.firestore();
 export { admin }; // <- Xuất ra để sử dụng ở chỗ khác
+export default admin;


### PR DESCRIPTION
## Summary
- export `admin` as the default from `src/firebase.js`
- authentication middleware continues to import the default firebase instance

## Testing
- `npm install`
- `node -e "import('./src/middleware/auth.js').then(m=>console.log('loaded')).catch(e=>console.error(e))"`
- `node -e "import('./src/routes/users.js').then(m=>console.log('loaded')).catch(e=>console.error(e))"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c4dc87978832cb35cdabbfefacb1c