### PR TITLE
Fix assets route validator and collection

### DIFF
--- a/src/routes/assets.js
+++ b/src/routes/assets.js
@@ -1,23 +1,23 @@
 import express from 'express';
-import { assetTypeSchema } from '../validators/assetTypeValidator.js';
+import { assetSchema } from '../validators/assetValidator.js';
 import { db } from '../firebase.js';
 
 const router = express.Router();
 
 router.post('/', async (req, res) => {
-  const result = assetTypeSchema.safeParse(req.body);
+  const result = assetSchema.safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.errors });
   }
   const data = result.data;
-  const docRef = await db.collection('asset_types').add(data);
+  const docRef = await db.collection('assets').add(data);
   return res.json({ id: docRef.id, ...data });
 });
 
 router.get('/', async (req, res) => {
-  const snapshot = await db.collection('asset_types').get();
-  const assetTypes = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-  res.json(assetTypes);
+  const snapshot = await db.collection('assets').get();
+  const assets = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  res.json(assets);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- use `assetSchema` in assets routes instead of `assetTypeSchema`
- write/read to `assets` collection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c4d64ce08832cab2e306bc731367d