### PR TITLE
Add dashboard stats endpoints

### DIFF
--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -1,0 +1,27 @@
+import { db } from '../firebase.js';
+import { groupTradesByMonth } from '../utils/tradeAggregations.js';
+
+export const getDashboardStats = async (req, res) => {
+  try {
+    const tradesCount = (await db.collection('trades').get()).size;
+    const accountsCount = (await db.collection('accounts').get()).size;
+    const usersCount = (await db.collection('users').get()).size;
+
+    res.json({ tradesCount, accountsCount, usersCount });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch dashboard stats' });
+  }
+};
+
+export const getTradesByMonth = async (req, res) => {
+  try {
+    const snapshot = await db.collection('trades').get();
+    const trades = snapshot.docs.map(doc => doc.data());
+    const data = groupTradesByMonth(trades);
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch trades by month' });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import aiInsightsRouter from './routes/aiInsights.js';
 import marketFlowsRouter from './routes/marketFlows.js';
 import flowInsightsRouter from './routes/flowInsights.js';
 import loginRouter from './routes/login.js';
+import dashboardRouter from './routes/dashboard.js';
 
 dotenv.config();
 const app = express();
@@ -43,6 +44,7 @@ app.use('/api/aiinsights', aiInsightsRouter);
 app.use('/api/market_flows', marketFlowsRouter);
 app.use('/api/flow_insights', flowInsightsRouter);
 app.use('/api/login', loginRouter);
+app.use('/api/dashboard', dashboardRouter);
 
 app.get('/', (req, res) => {
   res.send('Trading Journal API (Firestore) is up!');

--- a/src/routes/dashboard.js
+++ b/src/routes/dashboard.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { getDashboardStats, getTradesByMonth } from '../controllers/dashboardController.js';
+
+const router = express.Router();
+
+router.get('/stats', getDashboardStats);
+router.get('/trades_by_month', getTradesByMonth);
+
+export default router;

--- a/src/utils/tradeAggregations.js
+++ b/src/utils/tradeAggregations.js
@@ -1,0 +1,12 @@
+export function groupTradesByMonth(trades) {
+  const stats = {};
+  for (const trade of trades) {
+    if (!trade.entry_datetime) continue;
+    const month = new Date(trade.entry_datetime).toISOString().slice(0, 7);
+    stats[month] = (stats[month] || 0) + 1;
+  }
+
+  return Object.entries(stats)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, count]) => ({ month, count }));
+}

--- a/tests/tradeAggregations.test.js
+++ b/tests/tradeAggregations.test.js
@@ -1,0 +1,17 @@
+import { groupTradesByMonth } from '../src/utils/tradeAggregations.js';
+
+describe('groupTradesByMonth', () => {
+  test('groups trades by month', () => {
+    const trades = [
+      { entry_datetime: '2024-01-10T00:00:00Z' },
+      { entry_datetime: '2024-01-15T00:00:00Z' },
+      { entry_datetime: '2024-02-10T00:00:00Z' }
+    ];
+
+    const result = groupTradesByMonth(trades);
+    expect(result).toEqual([
+      { month: '2024-01', count: 2 },
+      { month: '2024-02', count: 1 }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- provide basic dashboard metrics and chart data
- expose `/api/dashboard` routes
- compute trades grouped by month
- test trade aggregation helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c7e356b9c832c83a4a1e00c5439e6