### PR TITLE
Implement full CRUD for account, asset and tag management

### DIFF
--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -1,35 +1,29 @@
 import express from 'express';
 import { accountSchema } from '../validators/accountValidator.js';
-import { db } from '../firebase.js';
+import {
+  createAccount,
+  getAccounts,
+  updateAccount,
+  deleteAccount,
+} from '../controllers/accountController.js';
 
 const router = express.Router();
 
 // Tạo tài khoản mới
-router.post('/', async (req, res) => {
+router.post('/', (req, res) => {
   const result = accountSchema.safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.errors });
   }
-  try {
-    const data = result.data;
-    const docRef = await db.collection('accounts').add(data);
-    return res.json({ id: docRef.id, ...data });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to create account' });
-  }
+  req.body = result.data;
+  return createAccount(req, res);
 });
 
 // Lấy tất cả tài khoản
-router.get('/', async (req, res) => {
-  try {
-    const snapshot = await db.collection('accounts').get();
-    const accounts = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-    res.json(accounts);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to fetch accounts' });
-  }
-});
+router.get('/', getAccounts);
+
+router.put('/:id', updateAccount);
+
+router.delete('/:id', deleteAccount);
 
 export default router;

--- a/src/routes/assets.js
+++ b/src/routes/assets.js
@@ -1,35 +1,27 @@
 import express from 'express';
 import { assetSchema } from '../validators/assetValidator.js';
-import { db } from '../firebase.js';
+import {
+  createAsset,
+  getAssets,
+  updateAsset,
+  deleteAsset,
+} from '../controllers/assetController.js';
 
 const router = express.Router();
 
-router.post('/', async (req, res) => {
+router.post('/', (req, res) => {
   const result = assetSchema.safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.errors });
   }
-
-  try {
-    const data = result.data;
-    const docRef = await db.collection('asset_types').add(data);
-    return res.json({ id: docRef.id, ...data });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to create asset type' });
-  }
+  req.body = result.data;
+  return createAsset(req, res);
 });
 
-router.get('/', async (req, res) => {
-  try {
-    const snapshot = await db.collection('asset_types').get();
-    const assetTypes = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-    res.json(assetTypes);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to fetch asset types' });
-  }
+router.get('/', getAssets);
 
-});
+router.put('/:id', updateAsset);
+
+router.delete('/:id', deleteAsset);
 
 export default router;

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -1,33 +1,27 @@
 import express from 'express';
 import { tagSchema } from '../validators/tagValidator.js';
-import { db } from '../firebase.js';
+import {
+  createTag,
+  getTags,
+  updateTag,
+  deleteTag,
+} from '../controllers/tagController.js';
 
 const router = express.Router();
 
-router.post('/', async (req, res) => {
+router.post('/', (req, res) => {
   const result = tagSchema.safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.errors });
   }
-  try {
-    const data = result.data;
-    const docRef = await db.collection('tags').add(data);
-    return res.json({ id: docRef.id, ...data });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to create tag' });
-  }
+  req.body = result.data;
+  return createTag(req, res);
 });
 
-router.get('/', async (req, res) => {
-  try {
-    const snapshot = await db.collection('tags').get();
-    const tags = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-    res.json(tags);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Failed to fetch tags' });
-  }
-});
+router.get('/', getTags);
+
+router.put('/:id', updateTag);
+
+router.delete('/:id', deleteTag);
 
 export default router;


### PR DESCRIPTION
## Summary
- route account operations through controller
- add update and delete endpoints for accounts
- route asset operations through controller
- add update and delete endpoints for assets
- route tag operations through controller
- add update and delete endpoints for tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c817657a0832c9e7a26d675bb89de